### PR TITLE
Fix basic test

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -14,7 +14,7 @@ fn main() {
         .add_plugins(
             WorldInspectorPlugin::default().run_if(input_toggle_active(false, KeyCode::Escape)),
         )
-        .insert_resource(LaMesaPluginSettings { num_players: 1 })
+        .insert_resource(LaMesaPluginSettings { num_players: 1, disable_card_animation: false })
         .insert_resource(GameState {
             game_started: false,
         })
@@ -135,6 +135,7 @@ pub fn button_system(
 
                 ew_shuffle.send(DeckShuffle {
                     deck_entity: deck_entity.clone(),
+                    duration: 8,
                 });
             }
             Interaction::Hovered => {


### PR DESCRIPTION
It still crashes at runtime when trying to draw a hand unfortunately, but at least it compiles now.

```
thread 'main' panicked at /Users/kernald/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_defer-0.13.3/src/lib.rs:257:14:
Requested non-send resource bevy_defer::executor::AsyncExecutor does not exist in the `World`.
                Did you forget to add it using `app.insert_non_send_resource` / `app.init_non_send_resource`?
                Non-send resources can also be added by plugins.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic when applying buffers for system `bevy_la_mesa::events::handle_draw_to_hand<basic::PokerCard>`!
Encountered a panic in system `bevy_ecs::schedule::executor::apply_deferred`!
2025-04-23T23:23:13.128319Z  WARN bevy_ecs::world::command_queue: CommandQueue has un-applied commands being dropped. Did you forget to call SystemState::apply?
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```